### PR TITLE
Fix for Issue #3: Avoid using unexported *line-buffer-size* from utf8-input-stream

### DIFF
--- a/cl-ollama.lisp
+++ b/cl-ollama.lisp
@@ -8,7 +8,8 @@
 (defparameter *port* 11434)
 (defparameter *read-timeout* 300)
 
-(setq utf8-input-stream:*line-buffer-size* 32)
+;; (setq utf8-input-stream:*line-buffer-size* 32)
+(setf (symbol-value (find-symbol "*LINE-BUFFER-SIZE*" :utf8-input-stream)) 32)
 
 (defun gen-url (verb &key (suffix ""))
   (let ((url (format nil "~a://~a:~a/api/~a" *protocol* *host* *port* verb)))


### PR DESCRIPTION
This PR fixes [Issue #3](https://github.com/veer66/cl-ollama/issues/3), which causes a compile-time error in SBCL:

> The symbol `*LINE-BUFFER-SIZE*` is not external in the UTF8-INPUT-STREAM package.

Instead of accessing `utf8-input-stream:*line-buffer-size*` directly (which is not portable), this patch uses `find-symbol` and `symbol-value`:

```lisp
(setf (symbol-value (find-symbol "*LINE-BUFFER-SIZE*" :utf8-input-stream)) 32)
```